### PR TITLE
Fix incompatible signature

### DIFF
--- a/dagster-cloud/dagster_cloud/storage/event_logs/storage.py
+++ b/dagster-cloud/dagster_cloud/storage/event_logs/storage.py
@@ -736,9 +736,9 @@ class GraphQLEventLogStorage(EventLogStorage, ConfigurableClass):
         ]
 
     def get_latest_materialization_events(
-        self, asset_keys: Sequence[AssetKey]
+        self, asset_keys: Iterable[AssetKey]
     ) -> Mapping[AssetKey, Optional[EventLogEntry]]:
-        check.list_param(asset_keys, "asset_keys", of_type=AssetKey)
+        check.iterable_param(asset_keys, "asset_keys", of_type=AssetKey)
 
         res = self._execute_query(
             GET_LATEST_MATERIALIZATION_EVENTS_QUERY,


### PR DESCRIPTION
`GraphQLEventLogStorage.get_latest_materialization_events` overrides the `EventLogStorage.get_latest_materialization_events` in an incompatible way, resulting in validation errors when running in the cloud vs. local `dagster dev` development.

See interface:
https://github.com/dagster-io/dagster/blob/456494d07413ebc781c08bcdfb22b69e419410d1/python_modules/dagster/dagster/_core/storage/event_log/base.py#L368-L372

(There are many more incompatible overrides in this file, but this is the only one that bothers us for now.)