### PR TITLE
Support service_spec_config for code location services

### DIFF
--- a/dagster-cloud/dagster_cloud/workspace/config_schema/__init__.py
+++ b/dagster-cloud/dagster_cloud/workspace/config_schema/__init__.py
@@ -161,6 +161,7 @@ K8S_CONFIG_FIELDS = {
                 ),
                 "deployment_metadata": Permissive(),
                 "service_metadata": Permissive(),
+                "service_spec_config": Permissive(),
             }
         ),
         is_required=False,

--- a/dagster-cloud/dagster_cloud/workspace/kubernetes/launcher.py
+++ b/dagster-cloud/dagster_cloud/workspace/kubernetes/launcher.py
@@ -209,7 +209,7 @@ class K8sUserCodeLauncher(DagsterCloudUserCodeLauncher[K8sHandle], ConfigurableC
                 {
                     key: val
                     for key, val in only_allow_user_defined_k8s_config_fields.items()
-                    if key not in {"service_metadata", "deployment_metadata"}
+                    if key not in {"service_metadata", "service_spec_config", "deployment_metadata"}
                 }
                 if only_allow_user_defined_k8s_config_fields
                 else only_allow_user_defined_k8s_config_fields
@@ -302,6 +302,7 @@ class K8sUserCodeLauncher(DagsterCloudUserCodeLauncher[K8sHandle], ConfigurableC
                             "pod_template_spec_metadata": Permissive(),
                             "deployment_metadata": Permissive(),
                             "service_metadata": Permissive(),
+                            "service_spec_config": Permissive(),
                         }
                     ),
                     is_required=False,
@@ -329,6 +330,9 @@ class K8sUserCodeLauncher(DagsterCloudUserCodeLauncher[K8sHandle], ConfigurableC
                                 Map(key_type=str, inner_type=bool), is_required=False
                             ),
                             "service_metadata": Field(
+                                Map(key_type=str, inner_type=bool), is_required=False
+                            ),
+                            "service_spec_config": Field(
                                 Map(key_type=str, inner_type=bool), is_required=False
                             ),
                             "namespace": Field(bool, is_required=False),

--- a/dagster-cloud/dagster_cloud/workspace/kubernetes/utils.py
+++ b/dagster-cloud/dagster_cloud/workspace/kubernetes/utils.py
@@ -88,6 +88,8 @@ def construct_code_location_service(
     user_defined_service_metadata = copy.deepcopy(dict(user_defined_k8s_config.service_metadata))
     user_defined_service_labels = user_defined_service_metadata.pop("labels", {})
 
+    service_spec_config = copy.deepcopy(dict(user_defined_k8s_config.service_spec_config))
+
     return k8s_model_from_dict(
         client.V1Service,
         {
@@ -104,6 +106,7 @@ def construct_code_location_service(
                 },
             },
             "spec": {
+                **service_spec_config,
                 "selector": {"user-deployment": service_name},
                 "ports": [{"name": "grpc", "protocol": "TCP", "port": get_code_server_port()}],
             },


### PR DESCRIPTION
## Summary

Adds `service_spec_config` support to `server_k8s_config`, allowing customization of the Kubernetes Service spec for code location servers. This enables headless services (`clusterIP: None`) and other service spec fields.

Closes #39

## Motivation

Each code location creates a ClusterIP service that consumes an IP from the cluster's service CIDR range. In hybrid deployments with many code locations across multiple deployments, this can exhaust the available service IPs. Headless services work fine here since the agent communicates with code servers via DNS.

## What's included

- `construct_code_location_service` in `utils.py` now reads and merges `service_spec_config` into the service spec dict
- `server_k8s_config` schema in `launcher.py` and `config_schema/__init__.py` accepts `service_spec_config: Permissive()`
- `only_allow_user_defined_k8s_config_fields` updated to include `service_spec_config`

## Dependencies

Requires a corresponding change in dagster-k8s (dagster-io/dagster) to add `service_spec_config` to `UserDefinedDagsterK8sConfig`, following the existing `pod_spec_config` / `job_spec_config` pattern.

## Usage

```yaml
# dagster.yaml
workspace:
  serverK8sConfig:
    serviceSpecConfig:
      clusterIP: None
```