### PR TITLE
Add dagster-cloud asset materialize CLI command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,17 @@
 > This changelog is deprecated. New releases will be documented in the main [Dagster Changelog](https://github.com/dagster-io/dagster/blob/master/CHANGES.md).
 
 
+# Unreleased
+
+### New
+
+- Added `dagster-cloud asset materialize` CLI command for triggering asset
+  materialization on Dagster Cloud deployments. Supports `--select` for
+  comma-separated asset keys, `--partition` for partitioned assets, `--location`
+  for targeting a specific code location, and `--wait` to block until the run
+  finishes. Follows the same authentication and URL resolution patterns as
+  `dagster-cloud job launch`.
+
 # 1.2.7
 
 ### New

--- a/dagster-cloud/dagster_cloud/asset/cli/__init__.py
+++ b/dagster-cloud/dagster_cloud/asset/cli/__init__.py
@@ -1,0 +1,145 @@
+cat > dagster_cloud/asset/cli/__init__.py << 'EOF'
+import json
+import time
+from typing import Any
+
+import typer
+from typer import Typer
+
+from dagster_cloud_cli import gql, ui
+from dagster_cloud_cli.config_utils import dagster_cloud_options
+
+app = Typer(help="Commands for working with Dagster Cloud assets.")
+
+# Dagster's internal synthetic job name for asset-backed jobs
+_ASSET_JOB_NAME = "__ASSET_JOB"
+
+# Default repository name for single-repository code locations
+_SINGLETON_REPOSITORY_NAME = "__repository__"
+
+
+@app.command(name="materialize")
+@dagster_cloud_options(allow_empty=True, requires_url=True)
+def materialize(
+    api_token: str,
+    url: str,
+    deployment: str | None,
+    select: str = typer.Option(
+        ...,
+        "--select",
+        "-s",
+        help=(
+            "Comma-separated asset keys to materialize. "
+            "Use '/' to separate path components within a key. "
+            "Examples: 'my_asset', 'asset1,asset2', 'prefix/asset1,prefix/asset2'"
+        ),
+    ),
+    location: str = typer.Option(
+        ...,
+        "-l",
+        "--location",
+        help="Code location name containing the assets.",
+    ),
+    repository: str = typer.Option(
+        None,
+        "-r",
+        "--repository",
+        help=(
+            "Repository name within the code location. "
+            "Defaults to the singleton repository if only one is defined."
+        ),
+    ),
+    partition: str | None = typer.Option(
+        None,
+        "--partition",
+        "-p",
+        help=(
+            "Partition key to materialize (e.g. '2024-01-15'). "
+            "Only applies to partitioned assets."
+        ),
+    ),
+    tags: str = typer.Option(
+        None,
+        "--tags",
+        help='JSON dict of additional run tags (e.g. \'{"team": "data"}\').',
+    ),
+    wait: bool = typer.Option(
+        False,
+        "-w",
+        "--wait",
+        help="Block until the run finishes and exit with a non-zero code on failure.",
+    ),
+    interval: int = typer.Option(
+        30,
+        "-i",
+        "--interval",
+        help="Polling interval in seconds when --wait is used.",
+    ),
+):
+    """Trigger asset materialization in a Dagster Cloud deployment.
+
+    \b
+    Examples:
+      dagster-cloud asset materialize -l my_location --select my_asset
+      dagster-cloud asset materialize -l my_location --select asset1,asset2
+      dagster-cloud asset materialize -l my_location --select prefix/asset1
+      dagster-cloud asset materialize -l my_location --select my_asset --partition 2024-01-15
+      dagster-cloud asset materialize -l my_location --select my_asset --wait
+    """
+    # Parse and validate tags
+    loaded_tags: dict[str, Any] = {}
+    if tags:
+        try:
+            loaded_tags = json.loads(tags)
+            if not isinstance(loaded_tags, dict):
+                raise ValueError("Tags must be a JSON object.")
+        except Exception as e:
+            raise ui.error(f"Invalid --tags value: {e}")
+
+    # Partitions are passed as a standard Dagster run tag
+    if partition:
+        loaded_tags["dagster/partition"] = partition
+
+    repo_name = repository or _SINGLETON_REPOSITORY_NAME
+
+    # Parse comma-separated asset keys; '/' separates path components within each key
+    asset_keys = [k.strip() for k in select.split(",") if k.strip()]
+    if not asset_keys:
+        raise ui.error("--select requires at least one asset key.")
+
+    with gql.graphql_client_from_url(url, api_token, deployment_name=deployment) as client:
+        run_id = gql.launch_run(
+            client,
+            location_name=location,
+            repo_name=repo_name,
+            job_name=_ASSET_JOB_NAME,
+            tags=loaded_tags,
+            config={},
+            asset_keys=asset_keys,
+        )
+
+    if wait:
+        ui.print(f"Run {run_id} launched. Waiting for completion...")
+        status = None
+        with gql.graphql_client_from_url(url, api_token, deployment_name=deployment) as client:
+            while True:
+                time.sleep(interval)
+                try:
+                    status = gql.run_status(client, run_id)
+                except Exception as e:
+                    raise ui.error(f"Failed to poll status for run {run_id}: {e}")
+
+                if status in ("SUCCESS", "FAILURE", "CANCELED"):
+                    break
+                ui.print(f"  Status: {status}...")
+
+        if status == "SUCCESS":
+            ui.print(f"Run {run_id} completed successfully.")
+        else:
+            raise ui.error(
+                f"Run {run_id} ended with status '{status}'. "
+                "Check the Dagster Cloud UI for details."
+            )
+    else:
+        ui.print(run_id)
+EOF

--- a/dagster-cloud/dagster_cloud/asset/cli/__init__.py
+++ b/dagster-cloud/dagster_cloud/asset/cli/__init__.py
@@ -1,4 +1,3 @@
-cat > dagster_cloud/asset/cli/__init__.py << 'EOF'
 import json
 import time
 from typing import Any
@@ -86,7 +85,6 @@ def materialize(
       dagster-cloud asset materialize -l my_location --select my_asset --partition 2024-01-15
       dagster-cloud asset materialize -l my_location --select my_asset --wait
     """
-    # Parse and validate tags
     loaded_tags: dict[str, Any] = {}
     if tags:
         try:
@@ -96,13 +94,11 @@ def materialize(
         except Exception as e:
             raise ui.error(f"Invalid --tags value: {e}")
 
-    # Partitions are passed as a standard Dagster run tag
     if partition:
         loaded_tags["dagster/partition"] = partition
 
     repo_name = repository or _SINGLETON_REPOSITORY_NAME
 
-    # Parse comma-separated asset keys; '/' separates path components within each key
     asset_keys = [k.strip() for k in select.split(",") if k.strip()]
     if not asset_keys:
         raise ui.error("--select requires at least one asset key.")
@@ -142,4 +138,3 @@ def materialize(
             )
     else:
         ui.print(run_id)
-EOF

--- a/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/entrypoint.py
+++ b/python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/entrypoint.py
@@ -1,0 +1,212 @@
+# The following allows logging calls with extra arguments
+# ruff: noqa: PLE1205
+import importlib.util
+import json
+import logging
+import time
+from collections.abc import Callable, Mapping
+from enum import Enum
+
+import typer
+from typer.models import CommandInfo
+
+from dagster_cloud_cli.commands.branch_deployment import app as branch_deployment_app
+from dagster_cloud_cli.commands.ci import app as ci_app
+from dagster_cloud_cli.commands.config import (
+    app as config_app,
+    app_configure as configure_app,
+)
+from dagster_cloud_cli.commands.deployment import app as deployment_app
+from dagster_cloud_cli.commands.integration import app as integration_app
+from dagster_cloud_cli.commands.job import app as job_app
+from dagster_cloud_cli.commands.organization import (
+    app as organization_app,
+    legacy_settings_app,
+)
+from dagster_cloud_cli.commands.run import app as run_app
+from dagster_cloud_cli.commands.serverless import app as serverless_app
+from dagster_cloud_cli.commands.workspace import app as workspace_app
+from dagster_cloud_cli.utils import create_stub_app
+from dagster_cloud_cli.version import __version__
+
+has_dagster_cloud = importlib.util.find_spec("dagster_cloud") is not None
+
+
+if has_dagster_cloud:
+    from dagster_cloud.agent.cli import app as agent_app  # type: ignore
+    from dagster_cloud.pex.grpc.server.cli import app as pex_app  # type: ignore
+    from dagster_cloud.asset.cli import app as asset_app  # type: ignore
+else:
+    agent_app = create_stub_app("dagster-cloud")
+    pex_app = create_stub_app("dagster-cloud")
+    asset_app = create_stub_app("dagster-cloud")
+
+
+def _import_commands(
+    parent: typer.Typer,
+    child: typer.Typer,
+    remap_fn: Callable[[CommandInfo], CommandInfo] | None = None,
+) -> None:
+    """Copies the commands from one Typer app to another.
+    Equivalent of `add_typer` but doesn't add a subcommand.
+    """
+    for raw_command in child.registered_commands:
+        command = remap_fn(raw_command) if remap_fn else raw_command
+        parent.registered_commands.append(command)
+
+
+def _rename_command(command_info: CommandInfo, name: str) -> CommandInfo:
+    return CommandInfo(
+        name=name,
+        cls=command_info.cls,
+        context_settings=command_info.context_settings,
+        callback=command_info.callback,
+        help=command_info.help,
+        epilog=command_info.epilog,
+        short_help=command_info.short_help,
+        options_metavar=command_info.options_metavar,
+        add_help_option=command_info.add_help_option,
+        no_args_is_help=command_info.no_args_is_help,
+        hidden=command_info.hidden,
+        deprecated=command_info.deprecated,
+        # This avoids an error if a user is using an older version of Typer, since
+        # `rich_help_panel` was added in typer==0.6.0.
+        **(
+            {"rich_help_panel": getattr(command_info, "rich_help_panel")}
+            if hasattr(command_info, "rich_help_panel")
+            else {}
+        ),
+    )
+
+
+app = typer.Typer(
+    help="CLI tools for working with Dagster Cloud.",
+    no_args_is_help=True,
+    context_settings={
+        "help_option_names": ["-h", "--help"],
+    },
+    pretty_exceptions_enable=False,  # don't display overly verbose stack traces
+)
+
+
+def version_callback(value: bool):
+    if value:
+        typer.echo(f"Dagster Cloud version: {__version__}")
+        raise typer.Exit()
+
+
+class LogFormat(Enum):
+    DEFAULT = "default"
+    FLUENTBIT = "fluentbit"
+
+
+class FluentbitJsonFormatter(logging.Formatter):
+    def __init__(self, fmt: str, json_fields: Mapping[str, str]):
+        super().__init__(fmt=fmt)
+        self.json_fields = dict(json_fields)
+
+    def format(self, record: logging.LogRecord) -> str:
+        log = super().format(record)
+        output = {
+            # Time format specified here: https://github.com/fluent/fluent-bit/blob/master/conf/parsers.conf#L35-L39
+            "time": time.strftime("%d/%b/%Y:%H:%M:%S %z", time.localtime(record.created)),
+            "log": log,
+            "status": record.levelname,
+            "logger": record.name,
+        }
+
+        if isinstance(record.args, dict):
+            for source_field, target_field in self.json_fields.items():
+                if source_field in record.args:
+                    output[target_field] = str(record.args[source_field])
+
+        return json.dumps(output)
+
+
+def log_format_callback(value: LogFormat):
+    if value == LogFormat.FLUENTBIT:
+        logger = logging.getLogger()
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            FluentbitJsonFormatter(
+                "%(module)s - %(message)s",
+                {"event_name": "event_name", "duration_seconds": "duration_seconds"},
+            )
+        )
+        logger.addHandler(handler)
+
+
+@app.callback()
+def main(
+    _version: bool = typer.Option(
+        False,
+        "--version",
+        "-v",
+        callback=version_callback,
+        is_eager=True,
+        show_default=False,
+        help="Show Dagster Cloud version.",
+    ),
+    log_format: LogFormat = typer.Option(
+        "default",
+        "--log-format",
+        envvar="DAGSTER_LOG_FORMAT",
+        callback=log_format_callback,
+        is_eager=True,
+        show_default=True,
+        help="Logging level and format",
+    ),
+):
+    return
+
+
+@app.command(hidden=True)
+def logtest() -> None:
+    logging.info("this is an info message")
+    logging.error("this is an error message")
+    logging.warning("this is a warning message")
+    try:
+        pass
+    except:
+        logging.exception("this is inside an exception")
+    logger = logging.getLogger("cloud-events")
+    logger.info(
+        "logger info message with some tags", {"event_name": "event.NAME", "duration_seconds": 0.11}
+    )
+    logger.error(
+        "logger error message with some tags",
+        {"event_name": "event.NAME", "duration_seconds": 0.11},
+    )
+
+
+app.add_typer(agent_app, name="agent", no_args_is_help=True)
+app.add_typer(config_app, name="config", no_args_is_help=True)
+app.add_typer(deployment_app, name="deployment", no_args_is_help=True)
+app.add_typer(organization_app, name="organization", no_args_is_help=True)
+app.add_typer(workspace_app, name="workspace", no_args_is_help=True, hidden=True)
+_import_commands(
+    deployment_app,
+    workspace_app,
+    remap_fn=lambda c: (
+        _rename_command(c, f"{c.name}-locations") if c.name and "location" not in c.name else c
+    ),
+)
+app.add_typer(branch_deployment_app, name="branch-deployment", no_args_is_help=True)
+app.add_typer(job_app, name="job", no_args_is_help=True)
+app.add_typer(asset_app, name="asset", no_args_is_help=True)
+app.add_typer(run_app, name="run", no_args_is_help=True, hidden=True)
+app.add_typer(serverless_app, name="serverless", no_args_is_help=True)
+app.add_typer(pex_app, name="pex", hidden=True, no_args_is_help=True)
+app.add_typer(ci_app, name="ci", no_args_is_help=True)
+app.add_typer(integration_app, name="integration", no_args_is_help=True)
+
+# Deprecated in favor of organization
+app.add_typer(legacy_settings_app, name="settings", hidden=True)
+
+_import_commands(app, configure_app)
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary

Closes #13

Adds a new `dagster-cloud asset materialize` command that triggers asset
materialization in a Dagster Cloud deployment via the GraphQL API.

## Usage
```bash
dagster-cloud asset materialize -l my_location --select my_asset
dagster-cloud asset materialize -l my_location --select asset1,asset2
dagster-cloud asset materialize -l my_location --select prefix/asset1
dagster-cloud asset materialize -l my_location --select my_asset --partition 2024-01-15
dagster-cloud asset materialize -l my_location --select my_asset --wait
```

## What changed

- `dagster-cloud/dagster_cloud/asset/cli/__init__.py` — new Typer app
  defining the `materialize` command
- `dagster-cloud/dagster_cloud/asset/__init__.py` — package marker
- `python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/entrypoint.py`
  — mounts the new `asset` subcommand group, following the same pattern
  as `job`, `run`, and `agent`
- `CHANGES.md` — changelog entry

## Implementation notes

- Reuses the existing `gql.launch_run()` function with `job_name="__ASSET_JOB"`,
  which is the synthetic job Dagster auto-generates for asset-backed jobs
- Reuses `gql.run_status()` for the `--wait` polling loop
- Follows the identical auth, URL resolution, and error handling pattern
  as `dagster-cloud job launch` and `dagster-cloud run status`
- Partitions are passed as the standard `dagster/partition` run tag
- The `entrypoint.py` change handles both cases: when `dagster-cloud` is
  installed (real import) and when it is not (stub app)

## Note for reviewers

The `entrypoint.py` file lives in the `dagster-cloud-cli` package in the
main `dagster-io/dagster` monorepo. This PR includes a copy of that file
with the two necessary additions. The corresponding change to the monorepo
would be a 3-line addition to
`python_modules/libraries/dagster-cloud-cli/dagster_cloud_cli/entrypoint.py`.